### PR TITLE
Feat: 우체국 UI 조정 및 신고 기능 추가

### DIFF
--- a/lib/app.dart
+++ b/lib/app.dart
@@ -25,7 +25,7 @@ class App extends GetView<BottomNavController> {
           extendBody: true,
           body: Stack(
             children: [
-              SafeArea(child: _body()),
+              _body(),
               // 🔻 떠 있는 커스텀 바텀네비
               Align(
                 alignment: Alignment.bottomCenter,

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -42,9 +42,9 @@ Future<void> main() async {
   WidgetsFlutterBinding.ensureInitialized();
 
   // 상태바, UI 표시 설정
-  SystemChrome.setEnabledSystemUIMode(SystemUiMode.manual,
-      overlays: [SystemUiOverlay.bottom] // 상단바 숨기기
-      );
+  SystemChrome.setEnabledSystemUIMode(
+    SystemUiMode.edgeToEdge,
+  );
 
   // 가로모드 X
   SystemChrome.setPreferredOrientations([DeviceOrientation.portraitUp]);

--- a/lib/service/post/report_service.dart
+++ b/lib/service/post/report_service.dart
@@ -1,0 +1,61 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_dotenv/flutter_dotenv.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class ReportService {
+  final Dio dio = Dio();
+
+  Future<bool> createReport({
+    required int reportedUserId,
+    required int letterId,
+    required String reason,
+  }) async {
+    try {
+      final baseUrl = dotenv.env['BASE_URL'] ?? 'http://dearxmas.com:3000';
+
+      final prefs = await SharedPreferences.getInstance();
+      final token = prefs.getString('accessToken');
+
+      if (token == null) {
+        print('ReportService: 토큰 없음');
+        return false;
+      }
+
+      // 서버가 요구하는 바디 형식
+      final data = {
+        "targetUserId": reportedUserId,
+        "letterId": letterId,
+        "reason": reason
+      };
+
+      print('ReportService: 신고 요청 시작');
+      print('신고 데이터: $data');
+
+      final response = await dio.post(
+        '$baseUrl/reports',
+        data: data,
+        options: Options(
+          headers: {
+            'Authorization': 'Bearer $token',
+            'Content-Type': 'application/json'
+          },
+          validateStatus: (status) => status != null && status < 500,
+        ),
+      );
+
+      print('ReportService: 서버 응답: ${response.statusCode}');
+      print(response.data);
+
+      if (response.statusCode == 201) {
+        print('ReportService: 신고 성공');
+        return true;
+      }
+
+      print('ReportService: 신고 실패 - 상태코드: ${response.statusCode}');
+      return false;
+    } catch (e) {
+      print('ReportService: 신고 요청 중 오류 발생: $e');
+      return false;
+    }
+  }
+}

--- a/lib/view/letter/letter_recived.dart
+++ b/lib/view/letter/letter_recived.dart
@@ -3,6 +3,7 @@ import 'package:dear_deer_demo/data/app_color.dart';
 import 'package:dear_deer_demo/data/font_styles.dart';
 import 'package:dear_deer_demo/data/image_data.dart';
 import 'package:dear_deer_demo/service/auth_service.dart';
+import 'package:dear_deer_demo/service/post/report_service.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_screenutil/flutter_screenutil.dart';
 import 'package:get/get.dart';
@@ -36,7 +37,13 @@ class LetterReceived extends StatelessWidget {
     final sender = arguments['sender'] ?? {};
     final senderName = sender['nickname'] ?? '보낸 사람 없음';
     final paperId = arguments['paperId'] ?? 1;
-    final presignedUrl = arguments['presignedUrl']; // 서버에서 받은 presignedUrl
+    final presignedUrl = arguments['presignedUrl'];
+
+    final int letterId = arguments['id'] ?? 0;
+    final int senderId = sender['id'] ?? 0;
+
+    print('LetterReceived: letterId = $letterId');
+    print('LetterReceived: senderId = $senderId');
 
     final paperAsset = _getPaperAsset(paperId);
 
@@ -48,14 +55,14 @@ class LetterReceived extends StatelessWidget {
 
     return Scaffold(
       backgroundColor: Colors.white,
-      appBar: _AppBar(),
+      appBar: _AppBar(letterId, senderId), // 수정된 부분
       body: _Body(controller, senderName, formattedDate, paperAsset, nickname,
           presignedUrl),
     );
   }
 
-  // MARK: AppBar
-  AppBar _AppBar() => AppBar(
+  // MARK: AppBar (letterId, senderId 전달 추가)
+  AppBar _AppBar(int letterId, int senderId) => AppBar(
         backgroundColor: Colors.white,
         elevation: 0,
         scrolledUnderElevation: 0,
@@ -66,6 +73,14 @@ class LetterReceived extends StatelessWidget {
             style: FontStyles.H2_bold_17,
           ),
         ),
+        actions: [
+          IconButton(
+            icon: const Icon(Icons.flag_outlined, color: Colors.red),
+            onPressed: () {
+              _openReportBottomSheet(letterId, senderId);
+            },
+          ),
+        ],
       );
 
   // MARK: Body
@@ -157,7 +172,7 @@ class LetterReceived extends StatelessWidget {
                     ),
                   ),
 
-                  // 이미지 표시 (첫 페이지에만)
+                  // 이미지 표시 (첫 페이지)
                   if (index == 0 &&
                       presignedUrl != null &&
                       presignedUrl.isNotEmpty) ...[
@@ -261,5 +276,69 @@ class LetterReceived extends StatelessWidget {
       default:
         return ImagePath.imageLetter1;
     }
+  }
+
+  // MARK: 신고 BottomSheet
+  void _openReportBottomSheet(int letterId, int senderId) {
+    Get.bottomSheet(
+      Container(
+        padding: const EdgeInsets.all(20),
+        decoration: const BoxDecoration(
+          color: Colors.white,
+          borderRadius: BorderRadius.vertical(top: Radius.circular(16)),
+        ),
+        child: Column(
+          mainAxisSize: MainAxisSize.min,
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              "신고 사유 선택",
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
+            ),
+            const SizedBox(height: 20),
+            _reportItem("사칭 및 사기", "IMPERSONATION_FRAUD", letterId, senderId),
+            _reportItem("성적인 콘텐츠", "SEXUAL_CONTENT", letterId, senderId),
+            _reportItem("스팸 및 낚시", "SPAM_AND_PHISHING", letterId, senderId),
+            _reportItem("욕설 및 비하", "ABUSIVE_LANGUAGE", letterId, senderId),
+            _reportItem("광고 및 상업적 목적", "COMMERCIAL_AD", letterId, senderId),
+            _reportItem("정치적 선동", "POLITICAL_PROPAGANDA", letterId, senderId),
+            const SizedBox(height: 10),
+          ],
+        ),
+      ),
+    );
+  }
+
+  // MARK: 신고 항목
+  Widget _reportItem(
+    String label,
+    String reason,
+    int letterId,
+    int senderId,
+  ) {
+    return ListTile(
+      title: Text(label),
+      onTap: () async {
+        final service = ReportService();
+
+        print('신고 요청 시작');
+        print('letterId: $letterId, senderId: $senderId, reason: $reason');
+
+        final success = await service.createReport(
+          reportedUserId: senderId,
+          letterId: letterId,
+          reason: reason,
+        );
+
+        if (success) {
+          print('신고 성공');
+          Get.back();
+          Get.snackbar('신고 완료', '신고가 접수되었습니다.');
+        } else {
+          print('신고 실패');
+          Get.snackbar('오류', '신고 중 문제가 발생했습니다.');
+        }
+      },
+    );
   }
 }

--- a/lib/view/letter/post.dart
+++ b/lib/view/letter/post.dart
@@ -23,14 +23,17 @@ class PostMain extends GetView<PostController> {
     return Scaffold(
       backgroundColor: AppColors.bgColor,
       appBar: _appBar(),
-      body: SingleChildScrollView(
-        child: Column(
-          children: [
-            _deerPostImage(),
-            _mainButtonsRow(),
-            _number(),
-            _otherServicesSection(),
-          ],
+      body: SafeArea(
+        bottom: true,
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              _deerPostImage(),
+              _mainButtonsRow(),
+              _number(),
+              _otherServicesSection(),
+            ],
+          ),
         ),
       ),
     );
@@ -53,7 +56,7 @@ class PostMain extends GetView<PostController> {
         child: Image.asset(
           ImagePath.deerPost,
           width: 360.w,
-          height: 190.h,
+          height: 165.h,
           fit: BoxFit.cover,
         ),
       );

--- a/lib/view/letter/post.dart
+++ b/lib/view/letter/post.dart
@@ -53,7 +53,7 @@ class PostMain extends GetView<PostController> {
         child: Image.asset(
           ImagePath.deerPost,
           width: 360.w,
-          height: 190.h,
+          height: 165.h,
           fit: BoxFit.cover,
         ),
       );


### PR DESCRIPTION
1. 받은 편지 상세 조회 화면에 신고 버튼 추가
	•	AppBar에 flag_outlined 아이콘 추가
	•	신고 아이콘 클릭 시 신고 사유 선택 BottomSheet 열림

2. 신고 BottomSheet 구현
	•	신고 사유 ENUM 리스트 반영
	•	IMPERSONATION_FRAUD
	•	SEXUAL_CONTENT
	•	SPAM_AND_PHISHING
	•	ABUSIVE_LANGUAGE
	•	COMMERCIAL_AD
	•	POLITICAL_PROPAGANDA
	•	신고 항목 클릭 시 ReportService 사용하여 서버로 신고 요청 전송

3. 신고 요청 성공/실패 처리
	•	성공 시: BottomSheet 닫히며 Snackbar “신고가 접수되었습니다”
	•	실패 시: Snackbar “신고 중 문제가 발생했습니다”

4. 코드 전체 리팩토링
	•	LetterReceived에 letterId / senderId 정상 전달되도록 수정
	•	ReportService에서 Swagger 형식에 맞게 파라미터 수정
